### PR TITLE
Update v-backup-user

### DIFF
--- a/bin/v-backup-user
+++ b/bin/v-backup-user
@@ -483,7 +483,6 @@ local_backup(){
     backups_count=$(echo "$backup_list" |wc -l)
     if [ "$BACKUPS" -le "$backups_count" ]; then
         backups_rm_number=$((backups_count - BACKUPS))
-        (( ++backups_rm_number))
 
         # Removing old backup
         for backup in $(echo "$backup_list" |head -n $backups_rm_number); do
@@ -599,7 +598,7 @@ ftp_backup() {
     fi
     backups_count=$(echo "$backup_list" |wc -l)
     if [ "$backups_count" -ge "$BACKUPS" ]; then
-        backups_rm_number=$((backups_count - BACKUPS + 1))
+        backups_rm_number=$((backups_count - BACKUPS))
         for backup in $(echo "$backup_list" |head -n $backups_rm_number); do 
             backup_date=$(echo $backup |sed -e "s/$user.//" -e "s/.tar$//")
             echo -e "$(date "+%F %T") Rotated ftp backup: $backup_date" |\
@@ -754,7 +753,7 @@ sftp_backup() {
     fi
     backups_count=$(echo "$backup_list" |wc -l)
     if [ "$backups_count" -ge "$BACKUPS" ]; then
-        backups_rm_number=$((backups_count - BACKUPS + 1))
+        backups_rm_number=$((backups_count - BACKUPS))
         for backup in $(echo "$backup_list" |head -n $backups_rm_number); do
             backup_date=$(echo $backup |sed -e "s/$user.//" -e "s/.tar.*$//")
             echo -e "$(date "+%F %T") Rotated sftp backup: $backup_date" |\
@@ -803,7 +802,7 @@ google_backup() {
     backup_list=$(${gsutil} ls gs://$BUCKET/$BPATH/$user.* 2>/dev/null)
     backups_count=$(echo "$backup_list" |wc -l)
     if [ "$backups_count" -ge "$BACKUPS" ]; then
-        backups_rm_number=$((backups_count - BACKUPS + 1))
+        backups_rm_number=$((backups_count - BACKUPS))
         for backup in $(echo "$backup_list" |head -n $backups_rm_number); do 
             echo -e "$(date "+%F %T") Roated gcp backup: $backup"
             $gsutil rm $backup > /dev/null 2>&1


### PR DESCRIPTION
I noticed that I always seemed to have 1 less backup than I was supposed to in my VestaCP. This fix resolves the issue for me.


Problem outlined:

- My VestaCP package says that I'm supposed to be allowed 3 backups.
- The backups tab of the GUI showed that I had 3 backups.
- I was never able to access the oldest backup (Almost like it wasn't actually there).
- I checked the backup folder using SSH and I found that I only ever have the latest 2 backups available.
- It was clear that a script was deleting the 3rd backup prematurely.